### PR TITLE
Add the ability to pass config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,9 @@ Pass config options (fake `server.cfg`) with `--`:
 plugin-runner path/to/plugin path/to/script.amx -- "port 8888" "long_call_time 2"
 ```
 
+Note that no `--` will result in no `server.cfg` existing, `--` with no options
+following will result in an empty `server.cfg` being generated, and options
+being given will obviously be written to the file.
+
 [build_url]: https://ci.appveyor.com/project/Zeex/plugin-runner/branch/master
 [build_badge_url]: https://ci.appveyor.com/api/projects/status/qutulepfiep5y06i/branch/master?svg=true

--- a/README.md
+++ b/README.md
@@ -14,5 +14,11 @@ Usage
 plugin-runner path/to/plugin path/to/script.amx
 ```
 
+Pass config options (fake `server.cfg`) with `--`:
+
+```
+plugin-runner path/to/plugin path/to/script.amx -- "port 8888" "long_call_time 2"
+```
+
 [build_url]: https://ci.appveyor.com/project/Zeex/plugin-runner/branch/master
 [build_badge_url]: https://ci.appveyor.com/api/projects/status/qutulepfiep5y06i/branch/master?svg=true

--- a/src/plugin-runner.cpp
+++ b/src/plugin-runner.cpp
@@ -310,9 +310,22 @@ void UnloadScript(AMX *amx) {
 } // anonymous namespace
 
 int main(int argc, char **argv) {
+  // Find the start of config options (`--`).
+  int opts = 0;
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "--") == 0) {
+      opts = i + 1;
+      if (opts == argc) {
+        opts = 0; // `--` with no following parameters.
+      }
+      argc = i; // Remainder of the code stops before `--`.
+      break;
+    }
+  }
+
   if (argc < 2) {
     std::fprintf(stderr,
-                 "Usage: plugin-runner [plugin1 [plugin2 [...]]] amx_file\n");
+                 "Usage: plugin-runner [plugin1 [plugin2 [...]]] amx_file [-- opt1 [opt2 [...]]]\n");
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
Example:

```
plugin-runner crashdetect slow.amx -- "long_call_time 2"
```

I wanted to write a test to see if the new crashdetect PR (https://github.com/Zeex/samp-plugin-crashdetect/pull/75) worked (once I actually fix it...), but the default setting is 5ms.  That's fine for real uses, not good for a test.  So this adds the ability to create a mock `server.cfg` for those plugins that read it.

Every setting after `--` is treated as a separate complete line in the new `server.cfg` (you could even write comments there if you really wanted to).  If there's no `--`, there's no file generated (and any existing one is deleted).